### PR TITLE
Fix test segmentation fault

### DIFF
--- a/EScript/Compiler/Compiler.cpp
+++ b/EScript/Compiler/Compiler.cpp
@@ -25,6 +25,7 @@
 #include "AST/UserFunctionExpr.h"
 #include "AST/ValueExpr.h"
 #include "../Objects/Callables/UserFunction.h"
+#include "../Utils/Logger.h"
 
 #include <functional>
 #include <iostream>
@@ -48,7 +49,7 @@ static bool _handlerInitialized UNUSED_ATTRIBUTE = initHandler(handlerRegistry);
 
 
 //! (ctor)
-Compiler::Compiler(Logger * _logger) : logger(_logger ? _logger : new StdLogger(std::cout)) {
+Compiler::Compiler(Logger & _logger) : logger(_logger) {
 }
 
 std::pair<ERef<UserFunction>,_CountedRef<StaticData>>

--- a/EScript/Compiler/Compiler.h
+++ b/EScript/Compiler/Compiler.h
@@ -10,7 +10,6 @@
 #define ES_COMPILER_H
 
 #include "../Utils/CodeFragment.h"
-#include "../Utils/Logger.h"
 #include "../Utils/StringId.h"
 #include "../Utils/StringData.h"
 #include "../Instructions/Instruction.h"
@@ -33,7 +32,7 @@ class ASTNode;
 
 class Compiler {
 	public:
-		Compiler(Logger * _logger = nullptr);
+		Compiler(Logger & _logger);
 
 		std::pair<ERef<UserFunction>,_CountedRef<StaticData>> compile(const CodeFragment & code,const std::vector<StringId>& injectedStaticVarNames);
 
@@ -42,9 +41,9 @@ class Compiler {
 	//! @name Logging
 	//	@{
 	public:
-		Logger * getLogger()const				{	return logger.get();	}
+		Logger & getLogger()const				{	return logger;	}
 	private:
-		_CountedRef<Logger> logger;
+		Logger & logger;
 	//	@}
 	// -------------
 

--- a/EScript/Compiler/Parser.cpp
+++ b/EScript/Compiler/Parser.cpp
@@ -25,6 +25,7 @@
 #include "../Consts.h"
 
 #include "../Utils/IO/IO.h"
+#include "../Utils/Logger.h"
 #include "../Objects/Callables/UserFunction.h"
 
 #include <cstdio>
@@ -2150,8 +2151,8 @@ ASTNode::refArray_t readExpressionsInBrackets(ParsingContext & ctxt,int & cursor
 // ---------------------------------
 
 //!	(ctor)
-Parser::Parser(Logger * _logger) :
-		logger(_logger ? _logger : new StdLogger(std::cout)) {
+Parser::Parser(Logger & _logger) :
+		logger(_logger) {
 	//ctor
 }
 
@@ -2163,7 +2164,7 @@ ERef<AST::Block> Parser::parse(const CodeFragment & code) {
 	tokenizer.defineToken("__DIR__",new TValueString(IO::dirname(code.getFilename())));
 
 	Tokenizer::tokenList_t tokens;
-	ParsingContext ctxt(tokens,code,*logger.get());
+	ParsingContext ctxt(tokens,code,logger);
 	ctxt.rootBlock = rootBlock.get();
 
 	/// 1. Tokenize

--- a/EScript/Compiler/Parser.h
+++ b/EScript/Compiler/Parser.h
@@ -13,7 +13,6 @@
 #include "Tokenizer.h"
 
 #include "../Utils/CodeFragment.h"
-#include "../Utils/Logger.h"
 
 #include <vector>
 
@@ -22,6 +21,7 @@
 #endif
 
 namespace EScript {
+class Logger;
 namespace AST{
 class Block;
 }
@@ -29,10 +29,10 @@ class Block;
 //! [Parser]
 class Parser {
 	public:
-		Parser(Logger * logger = nullptr);
+		Parser(Logger & _logger);
 		ERef<AST::Block> parse(const CodeFragment & code);
 	private:
-		_CountedRef<Logger> logger;
+		Logger & logger;
 
 };
 }

--- a/EScript/Runtime/Runtime.h
+++ b/EScript/Runtime/Runtime.h
@@ -122,20 +122,21 @@ class Runtime : public ExtObject {
 		std::string getCurrentFile()const;
 		int getCurrentLine()const;
 		uint32_t getLogCounter(Logger::level_t level)const;
-		LoggerGroup * getLogger()const					{	return logger.get();	}
-		Logger::level_t getLoggingLevel()				{	return logger->getMinLevel();	}
+		LoggerGroup & getLogger()						{	return logger;	}
+		const LoggerGroup & getLogger() const			{	return logger;	}
+		Logger::level_t getLoggingLevel()				{	return logger.getMinLevel();	}
 		std::string getStackInfo();
 		std::string getLocalStackInfo();
 
-		void log(Logger::level_t l,const std::string & s)	{	logger->log(l,s);	}
+		void log(Logger::level_t l,const std::string & s)	{	logger.log(l,s);	}
 		void resetLogCounter(Logger::level_t level);
 
 		void setAddStackInfoToExceptions(bool b);
-		void setLoggingLevel(Logger::level_t level)		{	logger->setMinLevel(level);	}
+		void setLoggingLevel(Logger::level_t level)		{	logger.setMinLevel(level);	}
 		void setTreatWarningsAsError(bool b);
 
 	private:
-		_CountedRef<LoggerGroup> logger;
+		LoggerGroup logger;
 	//	@}
 
 };

--- a/EScript/Runtime/RuntimeInternals.cpp
+++ b/EScript/Runtime/RuntimeInternals.cpp
@@ -1226,7 +1226,7 @@ void RuntimeInternals::warn(const std::string & s)const {
 	if(getActiveFCC()){
 		os<<" ('" << getActiveFCC()->getUserFunction()->getCode().getFilename() << "':~"<<getCurrentLine()<<")";
 	}
-	runtime.getLogger()->warn(os.str());
+	runtime.getLogger().warn(os.str());
 }
 
 // -------------------------------------------------------------

--- a/EScript/Utils/Logger.cpp
+++ b/EScript/Utils/Logger.cpp
@@ -7,8 +7,9 @@
 // Licensed under the MIT License. See LICENSE file for details.
 // ---------------------------------------------------------------------------------
 #include "Logger.h"
-#include <stdexcept>
 #include <iostream>
+#include <memory>
+#include <stdexcept>
 
 namespace EScript{
 
@@ -16,9 +17,10 @@ namespace EScript{
 
 // ------------------------------------------------
 // LoggerGroup
-void LoggerGroup::addLogger(const std::string & name,Logger * logger){
-	if(logger==nullptr)
+void LoggerGroup::addLogger(const std::string & name, const std::shared_ptr<Logger> & logger){
+	if (!logger) {
 		throw std::invalid_argument("addLogger(nullptr)");
+	}
 	loggerRegistry[name] = logger;
 }
 
@@ -31,6 +33,13 @@ void LoggerGroup::clearLoggers(){
 Logger * LoggerGroup::getLogger(const std::string & name){
 	const loggerRegistry_t::iterator lbIt = loggerRegistry.lower_bound(name);
 	if(lbIt!=loggerRegistry.end() && !(loggerRegistry.key_comp()(name, lbIt->first)) ){
+		return lbIt->second.get();
+	}
+	return nullptr;
+}
+const Logger * LoggerGroup::getLogger(const std::string & name) const{
+	const auto lbIt = loggerRegistry.lower_bound(name);
+	if(lbIt!=loggerRegistry.cend() && !(loggerRegistry.key_comp()(name, lbIt->first)) ){
 		return lbIt->second.get();
 	}
 	return nullptr;

--- a/EScript/Utils/Logger.h
+++ b/EScript/Utils/Logger.h
@@ -13,13 +13,14 @@
 #include "ObjRef.h"
 
 #include <map>
-#include <string>
+#include <memory>
 #include <ostream>
+#include <string>
 
 namespace EScript {
 
 //! [Logger]
-class Logger : public EReferenceCounter<Logger> {
+class Logger {
 	public:
 		enum level_t{
 			LOG_ALL = 0,
@@ -65,16 +66,17 @@ class Logger : public EReferenceCounter<Logger> {
 class LoggerGroup : public Logger {
 	public:
 		LoggerGroup(level_t _minLevel = LOG_ALL,level_t _maxLevel = LOG_NONE) : Logger(_minLevel,_maxLevel){}
-		virtual ~LoggerGroup(){}
+		virtual ~LoggerGroup() = default;
 
-		void addLogger(const std::string & name,Logger * logger);
+		void addLogger(const std::string & name, const std::shared_ptr<Logger> & logger);
 		bool removeLogger(const std::string & name);
 		void clearLoggers();
 		Logger * getLogger(const std::string & name);
+		const Logger * getLogger(const std::string & name) const;
 	private:
 		//! ---|> Logger
 		void doLog(level_t l,const std::string & msg) override;
-		typedef std::map<std::string, _CountedRef<Logger> > loggerRegistry_t;
+		using loggerRegistry_t = std::map<std::string, std::shared_ptr<Logger>>;
 		loggerRegistry_t loggerRegistry;
 };
 


### PR DESCRIPTION
valgrind reported invalid memory reads/writes for the reference counter when running EScript's test. Furthermore, there seemed to be cyclic references.